### PR TITLE
Fix sheepdog volume creation from image

### DIFF
--- a/cinder/volume/drivers/sheepdog.py
+++ b/cinder/volume/drivers/sheepdog.py
@@ -112,7 +112,7 @@ class SheepdogDriver(driver.VolumeDriver):
             # see volume/drivers/manager.py:_create_volume
             self._delete(volume)
             # convert and store into sheepdog
-            image_utils.convert_image(tmp, 'sheepdog:%s' % volume['name'],
+            image_utils.convert_image(tmp.name, 'sheepdog:%s' % volume['name'],
                                       'raw')
             self._resize(volume)
 


### PR DESCRIPTION
When creating a volume from an image, with sheepdog as the backend, cinder will try to run:

sudo cinder-rootwrap /etc/cinder/rootwrap.conf qemu-img convert -O raw <open GreenPipe '<fd:12>', mode 'w+b' at 0x35d6e60> sheepdog:volume-59e3326f-0f04-4205-8a78-a7669493d9bf

This is due to passing to image_utils.covert_image the tmp object, rather than the tmp.name
