### PR TITLE
SAN/Solaris driver fixes

### DIFF
--- a/cinder/volume/drivers/san/san.py
+++ b/cinder/volume/drivers/san/san.py
@@ -98,8 +98,7 @@ class SanDriver(driver.VolumeDriver):
             return utils.execute(*cmd, **kwargs)
         else:
             check_exit_code = kwargs.pop('check_exit_code', None)
-            command = ' '.join(cmd)
-            return self._run_ssh(command, check_exit_code)
+            return self._run_ssh(cmd, check_exit_code)
 
     def _run_ssh(self, cmd_list, check_exit_code=True, attempts=1):
         utils.check_ssh_injection(cmd_list)

--- a/cinder/volume/drivers/san/solaris.py
+++ b/cinder/volume/drivers/san/solaris.py
@@ -171,12 +171,12 @@ class SolarisISCSIDriver(SanISCSIDriver):
                 luid = items[0].strip()
                 return luid
 
-        msg = _('LUID not found for %(zfs_poolname)s. '
-                'Output=%(out)s') % {'zfs_poolname': zfs_poolname, 'out': out}
-        raise exception.VolumeBackendAPIException(data=msg)
+        return None
 
     def _is_lu_created(self, volume):
         luid = self._get_luid(volume)
+        if luid is None:
+            return False
         return luid
 
     def delete_volume(self, volume):
@@ -246,10 +246,14 @@ class SolarisISCSIDriver(SanISCSIDriver):
     def remove_export(self, context, volume):
         """Removes an export for a logical volume."""
 
+        if not self._is_lu_created(volume):
+                    return
+
         # This is the reverse of _do_export
         luid = self._get_luid(volume)
         iscsi_name = self._build_iscsi_target_name(volume)
         target_group_name = 'tg-%s' % volume['name']
+
 
         if self._view_exists(luid):
             self._execute('/usr/sbin/stmfadm', 'remove-view', '-l', luid, '-a')


### PR DESCRIPTION
Fixed error handling for the Solaris SAN volume driver. Missing (unknown) LUID no longer causes an error - None is returned from now on.

This allows other functions to raise an error or treat this as a normal situation (for example, on volume deletion, if no export had ever taken place).
Also repaired SSH execution argument passing for the SAN base - double string join was used, resulting in c h o p p e d  c o m m a n d s.
