### PR TITLE
Extend LVM brick functionality

### DIFF
--- a/cinder/brick/local_dev/lvm.py
+++ b/cinder/brick/local_dev/lvm.py
@@ -119,6 +119,62 @@ class LVM(executor.Executor):
         cmd = ['vgcreate', self.vg_name, ','.join(pv_list)]
         self._execute(*cmd, root_helper=self._root_helper, run_as_root=True)
 
+    def activate_vg(self):
+        """Activate the Volume Group associated with this instantiation.
+
+        :raises: putils.ProcessExecutionError
+        """
+
+        cmd = ['vgchange', '-ay', self.vg_name]
+        try:
+            self._execute(*cmd,
+                          root_helper=self._root_helper,
+                          run_as_root=True)
+        except putils.ProcessExecutionError as err:
+            LOG.exception(_LE('Error activating Volume Group'))
+            LOG.error(_LE('Cmd     :%s') % err.cmd)
+            LOG.error(_LE('StdOut  :%s') % err.stdout)
+            LOG.error(_LE('StdErr  :%s') % err.stderr)
+            raise
+
+    def deactivate_vg(self):
+        """Deactivate the Volume Group associated with this instantiation.
+
+        This forces LVM to release any reference to the device.
+
+        :raises: putils.ProcessExecutionError
+        """
+
+        cmd = ['vgchange', '-an', self.vg_name]
+        try:
+            self._execute(*cmd,
+                          root_helper=self._root_helper,
+                          run_as_root=True)
+        except putils.ProcessExecutionError as err:
+            LOG.exception(_LE('Error deactivating Volume Group'))
+            LOG.error(_LE('Cmd     :%s') % err.cmd)
+            LOG.error(_LE('StdOut  :%s') % err.stdout)
+            LOG.error(_LE('StdErr  :%s') % err.stderr)
+            raise
+
+    def destroy_vg(self):
+        """Destroy the Volume Group associated with this instantiation.
+
+        :raises: putils.ProcessExecutionError
+        """
+
+        cmd = ['vgremove', '-f', self.vg_name]
+        try:
+            self._execute(*cmd,
+                          root_helper=self._root_helper,
+                          run_as_root=True)
+        except putils.ProcessExecutionError as err:
+            LOG.exception(_LE('Error destroying Volume Group'))
+            LOG.error(_LE('Cmd     :%s') % err.cmd)
+            LOG.error(_LE('StdOut  :%s') % err.stdout)
+            LOG.error(_LE('StdErr  :%s') % err.stderr)
+            raise
+
     def _get_vg_uuid(self):
         (out, _err) = self._execute('env', 'LC_ALL=C', 'vgs', '--noheadings',
                                     '-o uuid', self.vg_name)
@@ -698,6 +754,51 @@ class LVM(executor.Executor):
                           run_as_root=True)
         except putils.ProcessExecutionError as err:
             LOG.exception(_LE('Error renaming logical volume'))
+            LOG.error(_LE('Cmd     :%s') % err.cmd)
+            LOG.error(_LE('StdOut  :%s') % err.stdout)
+            LOG.error(_LE('StdErr  :%s') % err.stderr)
+            raise
+
+    def pv_resize(self, pv_name, new_size_str):
+        """Extend the size of an existing PV (for virtual PVs)
+
+        :raises: putils.ProcessExecutionError
+        """
+        try:
+            self._execute('pvresize',
+                          '--setphysicalvolumesize', new_size_str,
+                          pv_name,
+                          root_helper=self._root_helper,
+                          run_as_root=True)
+        except putils.ProcessExecutionError as err:
+            LOG.exception(_LE('Error resizing physical volume'))
+            LOG.error(_LE('Cmd     :%s') % err.cmd)
+            LOG.error(_LE('StdOut  :%s') % err.stdout)
+            LOG.error(_LE('StdErr  :%s') % err.stderr)
+            raise
+
+    def extend_thinpool(self):
+        """Extends the size of the thinpool
+
+        This method extends the size of a thinpool to 95% the size of the VG,
+        only if the VG is configured as thin and owns a thinpool.
+
+        This method can be used after expanding a VG, no matter how.
+
+        :raises: putils.ProcessExecutionError
+        """
+        if self.vg_thin_pool is None:
+            return
+
+        new_size_str = self._calculate_thin_pool_size()
+        try:
+            self._execute('lvextend',
+                          '-L', new_size_str,
+                          "%s/%s-pool" % (self.vg_name, self.vg_name),
+                          root_helper=self._root_helper,
+                          run_as_root=True)
+        except putils.ProcessExecutionError as err:
+            LOG.exception(_LE('Error resizing physical volume'))
             LOG.error(_LE('Cmd     :%s') % err.cmd)
             LOG.error(_LE('StdOut  :%s') % err.stdout)
             LOG.error(_LE('StdErr  :%s') % err.stderr)

--- a/cinder/tests/brick/fake_lvm.py
+++ b/cinder/tests/brick/fake_lvm.py
@@ -24,6 +24,15 @@ class FakeBrickLVM(object):
         self.vg_free_space = '5.00'
         self.vg_name = vg_name
 
+    def activate_vg(self):
+        pass
+
+    def deactivate_vg(self):
+        pass
+
+    def destroy_vg(self):
+        pass
+
     def supports_thin_provisioning():
         return False
 
@@ -64,4 +73,10 @@ class FakeBrickLVM(object):
         pass
 
     def rename_volume(self, lv_name, new_name):
+        pass
+
+    def pv_resize(self, pv_name, new_size_str):
+        pass
+
+    def extend_thinpool(self):
         pass

--- a/etc/cinder/rootwrap.d/volume.filters
+++ b/etc/cinder/rootwrap.d/volume.filters
@@ -14,6 +14,19 @@ vgs: EnvFilter, env, root, LC_ALL=C, vgs
 lvs: EnvFilter, env, root, LC_ALL=C, lvs
 lvdisplay: EnvFilter, env, root, LC_ALL=C, lvdisplay
 
+# cinder/brick/local_dev/lvm.py: 'pvresize', '--setphysicalvolumesize', sizestr, pvname
+pvresize: CommandFilter, pvresize, root
+
+# cinder/brick/local_dev/lvm.py: 'vgcreate', vg_name, pv_list
+vgcreate: CommandFilter, vgcreate, root
+
+# cinder/brick/local_dev/lvm.py: 'vgremove', '-f', vgname
+vgremove: CommandFilter, vgremove, root
+
+# cinder/brick/local_dev/lvm.py: 'vgchange', '-an', vgname
+# cinder/brick/local_dev/lvm.py: 'vgchange', '-ay', vgname
+vgchange: CommandFilter, vgchange, root
+
 # cinder/volume/driver.py: 'lvcreate', '-L', sizestr, '-n', volume_name,..
 # cinder/volume/driver.py: 'lvcreate', '-L', ...
 lvcreate: CommandFilter, lvcreate, root
@@ -28,6 +41,7 @@ lvremove: CommandFilter, lvremove, root
 lvrename: CommandFilter, lvrename, root
 
 # cinder/volume/driver.py: 'lvextend', '-L' '%(new_size)s', '%(lv_name)s' ...
+# cinder/volume/driver.py: 'lvextend', '-L' '%(new_size)s', '%(thin_pool)s' ...
 lvextend: CommandFilter, lvextend, root
 
 # cinder/brick/local_dev/lvm.py: 'lvchange -a y -K <lv>'


### PR DESCRIPTION
This patch adds some new methods to the LVM brick:
- VG activation
- VG deactivation
- VG removal
- PV resizing
- Thinpool extension

Change-Id: I9070eb5557b5a0ccc0563785f22e5fff7ad332f8
