### PR TITLE
Openstack exceptions are in unicode

### DIFF
--- a/cinder/volume/drivers/nimble.py
+++ b/cinder/volume/drivers/nimble.py
@@ -389,7 +389,7 @@ def _connection_checker(func):
             try:
                 return func(self, *args, **kwargs)
             except NimbleAPIException as e:
-                if attempts < 1 and (re.search('SM-eaccess', str(e))):
+                if attempts < 1 and (re.search('SM-eaccess', unicode(e))):
                     LOG.info(_LI('Session might have expired.'
                                  ' Trying to relogin'))
                     self.login()


### PR DESCRIPTION
Resolves https://bugs.launchpad.net/cinder/+bug/1430575