### PR TITLE
fix in-use volume's attachments and attach_status not updated after volume migration.

### DIFF
--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -1822,14 +1822,14 @@ class VolumeManager(manager.SchedulerDependentManager):
                    'previous_status': volume.status,
                    'migration_status': 'success'}
 
-        if orig_volume_status == 'in-use':
-            attachments = volume.volume_attachment
+        if orig_volume_status == 'in-use' and len(attachments) > 0:
             for attachment in attachments:
                 rpcapi.attach_volume(ctxt, volume,
                                      attachment['instance_uuid'],
                                      attachment['attached_host'],
                                      attachment['mountpoint'],
                                      'rw')
+			updates.update({'attach_status': 'attached'})
         volume.update(updates)
         volume.save()
 

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -1829,7 +1829,7 @@ class VolumeManager(manager.SchedulerDependentManager):
                                      attachment['attached_host'],
                                      attachment['mountpoint'],
                                      'rw')
-			updates.update({'attach_status': 'attached'})
+            updates.update({'attach_status': 'attached'})
         volume.update(updates)
         volume.save()
 


### PR DESCRIPTION
We migrated a in-use volume from lvm backend to another, the vm's volume has been swapped successfully, but the volume's attachments and attach_status has not been updated. So we did some modifications to the function 'migrate_volume_completion' , and it succeed.