### PR TITLE
Fixed support for filtering of iscsi igroup targets in NetApp driver

### DIFF
--- a/cinder/volume/drivers/netapp/dataontap/block_7mode.py
+++ b/cinder/volume/drivers/netapp/dataontap/block_7mode.py
@@ -451,7 +451,7 @@ class NetAppBlockStorage7modeLibrary(block_base.NetAppBlockStorageLibrary):
         # we  don't filter these on operational state.
 
         return (super(NetAppBlockStorage7modeLibrary, self)
-                ._get_preferred_target_from_list(target_details_list))
+                ._get_preferred_target_from_list(target_details_list, filter))
 
     def _get_backing_flexvol_names(self):
         """Returns a list of backing flexvol names."""

--- a/cinder/volume/drivers/netapp/options.py
+++ b/cinder/volume/drivers/netapp/options.py
@@ -186,7 +186,13 @@ netapp_san_opts = [
                      'applied to the names of objects from the storage '
                      'backend which represent pools in Cinder. This option '
                      'is only utilized when the storage protocol is '
-                     'configured to use iSCSI or FC.')), ]
+                     'configured to use iSCSI or FC.')),
+
+    cfg.StrOpt('igroup_target_filters',
+               help=('This option will filter out target portals. '
+                     'Use a CSV with no spaces ex: 10.0.0.1,10.0.0.2')),
+
+    ]
 
 netapp_replication_opts = [
     cfg.MultiOpt('netapp_replication_aggregate_map',


### PR DESCRIPTION
This probably needs to be enhanced a bit but now it seems to work for our infrastructure. 

The original requirement was to exclude those targets that would show up when connecting to the ontap 7-mode service which returned all the open portals irrespective of any filters or access control lists. 

NOTE: 
What should probably happen instead of this driver's paradigm is to use the iscsiadm discovery utility and respect what is returned by polling. This would allow NetApp to provide only those services that are inside the access list. 