### PR TITLE
Update lenovo_client.py

### DIFF
--- a/cinder/volume/drivers/lenovo/lenovo_client.py
+++ b/cinder/volume/drivers/lenovo/lenovo_client.py
@@ -22,3 +22,6 @@ class LenovoClient(dothill_client.DotHillClient):
     def __init__(self, host, login, password, protocol, ssl_verify):
         super(LenovoClient, self).__init__(host, login, password, protocol,
                                            ssl_verify)
+    # overwrite original delete_snapshot
+    def delete_snapshot(self, snap_name):
+        self._request("/delete/snapshot", snap_name)


### PR DESCRIPTION
TrivialFix: Lenovo does not like the "cleanup" parameter, it throughs an exception. This patch slightly modifies the dothill_client.py function for the deletion of a snapshot.

The error message: "Exception during message handling: The command had an invalid parameter or unrecognized parameter. - Invalid or ambiguous parameter found: \<snapshotID\>"

Conclusion: Our Lenovo S3200 does not like the "cleanup" parameter.