### PR TITLE
Add gigabyte unit to values in VolumeSizeExceedsLimit exception message

### DIFF
--- a/cinder/exception.py
+++ b/cinder/exception.py
@@ -607,8 +607,8 @@ class VolumeSizeExceedsAvailableQuota(QuotaError):
 
 
 class VolumeSizeExceedsLimit(QuotaError):
-    message = _("Requested volume size %(size)d is larger than "
-                "maximum allowed limit %(limit)d.")
+    message = _("Requested volume size %(size)dG is larger than "
+                "maximum allowed limit %(limit)dG.")
 
 
 class VolumeBackupSizeExceedsAvailableQuota(QuotaError):


### PR DESCRIPTION
Currently when we get a VolumeSizeExceedsLimit exception,
we display the values in exception without units.Added
unit 'G' gigabytes to exception message.

Closes-Bug: 1673023