### PR TITLE
Fix issue where values of 0 result in malformed Netapp API XML requests

### DIFF
--- a/cinder/volume/drivers/netapp/dataontap/client/api.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/api.py
@@ -515,7 +515,7 @@ class NaElement(object):
                 if isinstance(data_struct[k], (dict, list, tuple)):
                     child.translate_struct(data_struct[k])
                 else:
-                    if data_struct[k]:
+                    if data_struct[k] is not None:
                         child.set_content(six.text_type(data_struct[k]))
                 self.add_child_elem(child)
         else:


### PR DESCRIPTION
I ran into this issue when attempting to set snapshot reserve to 0 and received the Netapp API error "Invalid integer value for percentage: (null)".