### PR TITLE
Verify SSL connection if configured to do so

### DIFF
--- a/cinder/volume/drivers/nimble.py
+++ b/cinder/volume/drivers/nimble.py
@@ -1655,7 +1655,7 @@ class NimbleRestAPIExecutor(object):
     def get_query(self, api, query):
         url = self.uri + api
         return requests.get(url, headers=self.headers,
-                            params=query, verify=False)
+                            params=query, verify=self.verify)
 
     @_connection_checker
     def put(self, api, payload):


### PR DESCRIPTION
This uses the passed in 'verify' option to verify SSL connections to nimble API and stops logging warnings. 

