### PR TITLE
volume/drivers/qnap.py: fix login in a Python3 environment

### DIFF
--- a/cinder/volume/drivers/qnap.py
+++ b/cinder/volume/drivers/qnap.py
@@ -1227,7 +1227,7 @@ class QnapAPIExecutor(object):
     def execute_login(self):
         """Login and return sid."""
         params = OrderedDict()
-        params['pwd'] = base64.b64encode(self.password.encode("utf-8"))
+        params['pwd'] = str(base64.b64encode(self.password.encode("utf-8")), "utf-8")
         params['serviceKey'] = '1'
         params['user'] = self.username
 


### PR DESCRIPTION
In python3 (used e.g. in the Debian packages), base64.b64encode returns bytes, not a string - which leads to a "wrapping" with b'<string>' and thus to a broken login.

Therefore, wrap it in a str() cast to provide a working login again.

To check in a CLI:

```
>>> s=base64.b64encode("1234".encode("utf-8"))
>>> s
b'MTIzNA=='
>>> type(s)
<class 'bytes'>
>>> s=str(base64.b64encode("1234".encode("utf-8")),"utf-8")
>>> s
'MTIzNA=='
```