### PR TITLE
Add pure_iscsi_cidrs list parameter

### DIFF
--- a/cinder/tests/unit/volume/drivers/test_pure.py
+++ b/cinder/tests/unit/volume/drivers/test_pure.py
@@ -83,6 +83,8 @@ AC_ISCSI_IPS = ["10.0.0." + str(i + 1 + len(ISCSI_PORT_NAMES))
 ISCSI_CIDR = "0.0.0.0/0"
 # Designed to filter out only one of the AC ISCSI IPs, leaving the rest in
 ISCSI_CIDR_FILTERED = '10.0.0.0/29'
+# Include several IP / networks: 10.0.0.2, 10.0.0.3, 10.0.0.6, 10.0.0.7
+ISCSI_CIDRS_FILTERED = ['10.0.0.2','10.0.0.3','10.0.0.6/31']
 FC_WWNS = ["21000024ff59fe9" + str(i + 1) for i in range(len(FC_PORT_NAMES))]
 AC_FC_WWNS = [
     "21000024ff59fab" + str(i + 1) for i in range(len(FC_PORT_NAMES))]
@@ -231,6 +233,23 @@ ISCSI_CONNECTION_INFO_AC_FILTERED = {
                            ISCSI_IPS[2] + ":" + TARGET_PORT,
                            ISCSI_IPS[3] + ":" + TARGET_PORT,
                            AC_ISCSI_IPS[0] + ":" + TARGET_PORT,
+                           AC_ISCSI_IPS[1] + ":" + TARGET_PORT,
+                           AC_ISCSI_IPS[2] + ":" + TARGET_PORT],
+        "wwn": "3624a93709714b5cb91634c470002b2c8",
+    },
+}
+ISCSI_CONNECTION_INFO_AC_FILTERED_LIST = {
+    "driver_volume_type": "iscsi",
+    "data": {
+        "target_discovered": False,
+        "discard": True,
+        "target_luns": [1, 1, 5, 5],
+        # Final entry filtered by ISCSI_CIDR_FILTERED
+        "target_iqns": [TARGET_IQN, TARGET_IQN,
+                        AC_TARGET_IQN, AC_TARGET_IQN],
+        # Final entry filtered by ISCSI_CIDR_FILTERED
+        "target_portals": [ISCSI_IPS[1] + ":" + TARGET_PORT,
+                           ISCSI_IPS[2] + ":" + TARGET_PORT,
                            AC_ISCSI_IPS[1] + ":" + TARGET_PORT,
                            AC_ISCSI_IPS[2] + ":" + TARGET_PORT],
         "wwn": "3624a93709714b5cb91634c470002b2c8",
@@ -3217,6 +3236,53 @@ class PureISCSIDriverTestCase(PureBaseSharedDriverTestCase):
         # ActiveCluster addresses from above, so we should check that we only
         # get four+three results back
         self.driver.configuration.pure_iscsi_cidr = ISCSI_CIDR_FILTERED
+        mock_secondary = mock.MagicMock()
+        self.driver._uniform_active_cluster_target_arrays = [mock_secondary]
+
+        real_result = self.driver.initialize_connection(vol,
+                                                        ISCSI_CONNECTOR)
+        self.assertDictEqual(result, real_result)
+        mock_get_iscsi_ports.assert_has_calls([
+            mock.call(self.array),
+            mock.call(mock_secondary),
+        ])
+        mock_connection.assert_has_calls([
+            mock.call(self.array, vol_name, ISCSI_CONNECTOR, None, None),
+            mock.call(mock_secondary, vol_name, ISCSI_CONNECTOR, None, None),
+        ])
+
+    @mock.patch(ISCSI_DRIVER_OBJ + "._get_wwn")
+    @mock.patch(ISCSI_DRIVER_OBJ + "._connect")
+    @mock.patch(ISCSI_DRIVER_OBJ + "._get_target_iscsi_ports")
+    def test_initialize_connection_uniform_ac_cidrs(self,
+                                                   mock_get_iscsi_ports,
+                                                   mock_connection,
+                                                   mock_get_wwn):
+        repl_extra_specs = {
+            'replication_type': '<in> sync',
+            'replication_enabled': '<is> true',
+        }
+        vol, vol_name = self.new_fake_vol(type_extra_specs=repl_extra_specs)
+        mock_get_iscsi_ports.side_effect = [ISCSI_PORTS, AC_ISCSI_PORTS]
+        mock_get_wwn.return_value = '3624a93709714b5cb91634c470002b2c8'
+        mock_connection.side_effect = [
+            {
+                "vol": vol_name,
+                "lun": 1,
+            },
+            {
+                "vol": vol_name,
+                "lun": 5,
+            }
+        ]
+        result = deepcopy(ISCSI_CONNECTION_INFO_AC_FILTERED_LIST)
+
+        self.driver._is_active_cluster_enabled = True
+        # Set up some CIDRs to block: this will allow only 2 addresses from
+        # each host of the ActiveCluster, so we should check that we only
+        # get two+two results back
+        self.driver.configuration.pure_iscsi = ISCSI_CIDR
+        self.driver.configuration.pure_iscsi_cidrs = ISCSI_CIDRS_FILTERED
         mock_secondary = mock.MagicMock()
         self.driver._uniform_active_cluster_target_arrays = [mock_secondary]
 

--- a/cinder/volume/drivers/pure.py
+++ b/cinder/volume/drivers/pure.py
@@ -2427,12 +2427,14 @@ class PureISCSIDriver(PureBaseVolumeDriver, san.SanISCSIDriver):
             cidr = self.configuration.pure_iscsi_cidr.decode('utf8')
         else:
             cidr = self.configuration.pure_iscsi_cidr
-#        check_cidr = ipaddress.IPv4Network(cidr)
 
         cidrs = self.configuration.pure_iscsi_cidrs
 
         if not cidrs:
             cidrs.append(cidr)
+        else:
+            LOG.warning("pure_iscsi_cidr was ignored as pure_iscsi_cidrs is set")
+
         check_cidrs = [ipaddress.ip_network(item) for item in cidrs]
 
         target_luns = []

--- a/cinder/volume/drivers/pure.py
+++ b/cinder/volume/drivers/pure.py
@@ -85,11 +85,10 @@ PURE_OPTS = [
     cfg.StrOpt("pure_iscsi_cidr", default="0.0.0.0/0",
                help="CIDR of FlashArray iSCSI targets hosts are allowed to "
                     "connect to. Default will allow connection to any "
-                    "IP address."),
+                    "IP address. Ignored when pure_iscsi_cidrs is set."),
     cfg.ListOpt("pure_iscsi_cidrs", default=[],
                help="CIDRs of FlashArray iSCSI targets hosts are allowed to "
-                    "connect to. Default will allow connection to any "
-                    "IP address."),
+                    "connect to. This parameter superceeds pure_iscsi_cidr."),
     cfg.BoolOpt("pure_eradicate_on_delete",
                 default=False,
                 help="When enabled, all Pure volumes, snapshots, and "

--- a/releasenotes/notes/pure-iscsi-cidrs-7195eda9f7214fce.yaml
+++ b/releasenotes/notes/pure-iscsi-cidrs-7195eda9f7214fce.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Pure Storage FlashArray driver: added configuration option
+    ``pure_iscsi_cidrs`` for setting several network CIDRs for iSCSI target
+    connection. The default still allows all targets.


### PR DESCRIPTION
Following the idea of the `pure_iscsi_cidr`, we needed to have a way to select more than one address/network.

This is a proposed implementation.