### PR TITLE
Replacing incorrect dictionary API usage with a correct one

### DIFF
--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -212,7 +212,7 @@ class API(base.Base):
         specs = volume_type.get('extra_specs', {})
         if 'encryption' not in specs:
             return False
-        return specs.get('encryption', {}) is not {}
+        return specs.get('encryption') is not None
 
     def create(self,
                context: context.RequestContext,


### PR DESCRIPTION
In file: api.py, method: _is_encrypted, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not have an identity match with anything else and so the expression will always evaluate to True. The developer may wish to determine if the dictionary 'specs' contains a key named 'encryption'. Based on this assumption, this PR replaced the statement with a statement that correctly determines whether a dictionary contains a particular key. 